### PR TITLE
Bump dependency minor versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :default do
-  gem 'json', '~> 2.3.0'
-  gem 'ruby-progressbar', '~> 1.10.0'
+  gem 'json', '~> 2.5.0'
+  gem 'ruby-progressbar', '~> 1.11.0'
 end
 
 group :development do
   gem 'byebug', '~> 11.1.0'
-  gem 'rubocop', '~> 0.90.0'
+  gem 'rubocop', '~> 1.13.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,35 +3,35 @@ GEM
   specs:
     ast (2.4.2)
     byebug (11.1.3)
-    json (2.3.1)
+    json (2.5.1)
     parallel (1.20.1)
     parser (3.0.1.0)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (0.90.0)
+    rubocop (1.13.0)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.3.0, < 1.0)
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.8.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.7.0)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug (~> 11.1.0)
-  json (~> 2.3.0)
-  rubocop (~> 0.90.0)
-  ruby-progressbar (~> 1.10.0)
+  json (~> 2.5.0)
+  rubocop (~> 1.13.0)
+  ruby-progressbar (~> 1.11.0)
 
 BUNDLED WITH
    2.2.15


### PR DESCRIPTION
* 'json', '~> 2.5.0'
* 'rubocop', '~> 1.13.0'
* 'ruby-progressbar', '~> 1.11.0'