### PR TITLE
Dependency updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,11 @@ GEM
     ast (2.4.2)
     byebug (11.1.3)
     json (2.5.1)
-    parallel (1.20.1)
-    parser (3.0.1.0)
+    parallel (1.22.1)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
-    rainbow (3.0.0)
-    regexp_parser (2.1.1)
+    rainbow (3.1.1)
+    regexp_parser (2.4.0)
     rexml (3.2.5)
     rubocop (1.13.0)
       parallel (~> 1.10)
@@ -19,10 +19,10 @@ GEM
       rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
+    rubocop-ast (1.18.0)
+      parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    unicode-display_width (2.0.0)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
@@ -34,4 +34,4 @@ DEPENDENCIES
   ruby-progressbar (~> 1.11.0)
 
 BUNDLED WITH
-   2.2.17
+   2.3.10


### PR DESCRIPTION
Transitive dependencies:

  * parallel (1.22.1)
  * parser (3.1.2.0)
  * rainbow (3.1.1)
  * regexp_parser (2.4.0)
  * rubocop-ast (1.18.0)
  * unicode-display_width (2.1.0)